### PR TITLE
Made compatible with release version of Compose 1.2.0

### DIFF
--- a/buildSrc/src/main/java/ConfigData.kt
+++ b/buildSrc/src/main/java/ConfigData.kt
@@ -1,6 +1,6 @@
 object ConfigData {
     const val APPLICATION_ID = "com.memeze.sample"
-    const val COMPILE_SDK = 31
+    const val COMPILE_SDK = 32
     const val MIN_SDK = 21
     const val TARGET_SDK = 31
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,7 +31,7 @@ object Libs {
     }
 
     object Desugar {
-        val jdk by lazy { "com.android.tools:desugar_jdk_libs:1.1.5" }
+        val jdk by lazy { "com.android.tools:desugar_jdk_libs:1.1.6" }
     }
 
     object Lifecycle {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,11 +1,11 @@
 object Versions {
-    const val ACCOMPANIST = "0.23.1"    // Used in compose 1.1.x version
-    const val ACTIVITY = "1.4.0"
-    const val APPCOMPAT = "1.3.1"
-    const val COMPOSE = "1.1.1"
-    const val CORE_KTX = "1.6.0"
+    const val ACCOMPANIST = "0.25.0"    // Used in compose 1.1.x version
+    const val ACTIVITY = "1.5.1"
+    const val APPCOMPAT = "1.4.2"
+    const val COMPOSE = "1.2.0"
+    const val CORE_KTX = "1.8.0"
     const val GRADLE_PLUGIN = "7.1.3"
     const val JUNIT = "4.13.2"
-    const val KOTLIN = "1.6.10"
-    const val LIFECYCLE = "2.4.1"
+    const val KOTLIN = "1.7.0"
+    const val LIFECYCLE = "2.5.1"
 }

--- a/minimalcalendar/build.gradle.kts
+++ b/minimalcalendar/build.gradle.kts
@@ -43,7 +43,6 @@ android {
         freeCompilerArgs = freeCompilerArgs.plus(
             listOf(
                 "-Xopt-in=com.google.accompanist.pager.ExperimentalPagerApi",
-                "-Xopt-in=androidx.compose.foundation.ExperimentalFoundationApi",
                 "-Xopt-in=androidx.compose.ui.ExperimentalComposeUiApi",
                 "-Xopt-in=androidx.compose.animation.ExperimentalAnimationApi"
             )

--- a/minimalcalendar/src/main/java/com/memeze/minimalcalendar/ui/MinimalCalendarDays.kt
+++ b/minimalcalendar/src/main/java/com/memeze/minimalcalendar/ui/MinimalCalendarDays.kt
@@ -19,9 +19,9 @@ package com.memeze.minimalcalendar.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -53,7 +53,7 @@ internal fun MinimalCalendarDays(
 
     LazyVerticalGrid(
         modifier = modifier,
-        cells = GridCells.Fixed(DAY_OF_WEEK_COUNT)
+        columns = GridCells.Fixed(DAY_OF_WEEK_COUNT)
     ) {
         for (x in 0 until calendarDatesData.first) {
             item { Box(modifier = Modifier.size(DAY_ITEM_SIZE.dp)) }

--- a/minimalcalendar/src/main/java/com/memeze/minimalcalendar/ui/MinimalCalendarWeek.kt
+++ b/minimalcalendar/src/main/java/com/memeze/minimalcalendar/ui/MinimalCalendarWeek.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.memeze.minimalcalendar.config.Constant
 import com.memeze.minimalcalendar.config.Constant.DEFAULT_PADDING
 import com.memeze.minimalcalendar.config.Constant.WEEK_HEIGHT
 import com.memeze.minimalcalendar.config.MinimalCalendarColors


### PR DESCRIPTION
That's all, only minor changes were needed for the stabilization of `LazyVerticalGrid`.